### PR TITLE
Upgrade to LiteFS 0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM flyio/litefs:0.3.0-beta6 AS litefs
-
 FROM golang AS builder
 WORKDIR /src
 
@@ -21,7 +19,7 @@ RUN set -x && apt-get update && \
 
 ADD litefs.yml /etc/litefs.yml
 
-COPY --from=litefs /usr/local/bin/litefs ./
+COPY --from=flyio/litefs:0.4 /usr/local/bin/litefs ./
 COPY --from=builder /bin/server ./
 
 CMD ["./litefs", "mount"]

--- a/fly.toml
+++ b/fly.toml
@@ -6,15 +6,14 @@ kill_timeout = 5
 processes = []
 
 [env]
-  DATABASE_URL = "file:/data/app.db"
+  DATABASE_URL = "/litefs/app.db"
 
 [experimental]
   allowed_public_ports = []
   auto_rollback = true
-  enable_consul = true
 
 [mounts]
-  destination = "/mnt/data"
+  destination = "/data"
   source = "data"
 
 [[services]]

--- a/litefs.yml
+++ b/litefs.yml
@@ -1,14 +1,17 @@
 # The path to where the SQLite database will be accessed.
-mount-dir: "/data"
+fuse:
+  dir: "/litefs"
 
 # The path to where the underlying volume mount is.
-data-dir: "/mnt/data"
+data:
+  dir: "/data"
 
 # Execute this subprocess once LiteFS connects to the cluster.
 exec: "/app/server"
 
-# These environment variables will be available in your Fly.io application.
-# You must specify "experiement.enable_consul" for FLY_CONSUL_URL to be available.
-consul:
-  url: "${FLY_CONSUL_URL}"
+lease:
+  type: "consul"
   advertise-url: "http://${HOSTNAME}.vm.${FLY_APP_NAME}.internal:20202"
+  consul:
+    url: "${FLY_CONSUL_URL}"
+    key: "litefs/${FLY_APP_NAME}"


### PR DESCRIPTION
- Config file format is different
- Paths have been changed to be more clear about what's what (`/data` and `/mnt/data` vs. `/litefs` and `/data`)
- Consul is now attached through a command `fly consul attach` instead of in the config file